### PR TITLE
Added link to documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,10 @@
         <td><b>Matrix</b></td>
         <td><a href="https://matrix.to/#/#maubot:maunium.net">#maubot:maunium.net</a></td>
       </tr>
+      <tr>
+        <td><b>Documentation</b></td>
+        <td><a href="https://docs.mau.fi/maubot/">docs.mau.fi/maubot</a></td>
+      </tr>
     </table>
   </div>
 </body>


### PR DESCRIPTION
I often find myself going to maubot.xyz because that is an easy link to remember when looking for the documentation. But I have to click on the github, then find the documentation from there which is quite frustrating. This just adds a direct link to the documentation to have me, and hopefully others a bit of time.